### PR TITLE
🔥 Remove docker and docker-compose package ecosystems from dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -28,19 +28,3 @@ updates:
       timezone: America/Toronto
     commit-message:
       prefix: "⬆️ "
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: monthly
-      timezone: America/Toronto
-    commit-message:
-      prefix: "⬆️ "
-
-  - package-ecosystem: docker-compose
-    directory: /
-    schedule:
-      interval: monthly
-      timezone: America/Toronto
-    commit-message:
-      prefix: "⬆️ "


### PR DESCRIPTION
Apparently, the docker and docker-compose ecosystems require a Dockerfile. I don't have that here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated dependency management settings to discontinue automated updates for Docker and Docker Compose, reducing noise and maintenance overhead.
  - Dependency monitoring continues via npm and GitHub Actions, ensuring key ecosystems remain covered for updates and security alerts.
  - No runtime or user-facing changes; application behaviour and functionality remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->