### PR TITLE
✨ Add SSH passthrough to Forgejo

### DIFF
--- a/phantom/forgejo/.env.forgejo
+++ b/phantom/forgejo/.env.forgejo
@@ -5,6 +5,10 @@ FORGEJO__server__SSH_DOMAIN=
 FORGEJO__mailer__ENABLED=false
 FORGEJO__mailer__FROM=
 FORGEJO__mailer__PASSWD=
+FORGEJO__mailer__PROTOCOL=
 FORGEJO__mailer__SMTP_ADDR=
-FORGEJO__mailer__SMTP_PORT=465
+FORGEJO__mailer__SMTP_PORT=
 FORGEJO__mailer__USER=
+
+USER_UID=
+USER_GID=

--- a/phantom/forgejo/README.md
+++ b/phantom/forgejo/README.md
@@ -15,7 +15,7 @@
    echo "USER_GID=$(id -g git)" >> .env.forgejo.local
    ```
 
-3. Generate a SSH key
+3. Generate an SSH key
 
    ```sh
    sudo -u git ssh-keygen -t ed25519 -C "Forgejo"

--- a/phantom/forgejo/README.md
+++ b/phantom/forgejo/README.md
@@ -1,0 +1,42 @@
+# Forgejo
+
+## Setup SSH Passthrough
+
+1. Create a user
+
+   ```sh
+   sudo adduser git
+   ```
+
+2. Set `USER_UID` and `USER_GID` in `.env.forgejo.local`
+
+   ```sh
+   echo "USER_UID=$(id -u git)" >> .env.forgejo.local
+   echo "USER_GID=$(id -g git)" >> .env.forgejo.local
+   ```
+
+3. Generate a SSH key
+
+   ```sh
+   sudo -u git ssh-keygen -t ed25519 -C "Forgejo"
+   sudo -u git cat /home/git/.ssh/id_ed25519.pub | sudo -u git tee -a /home/git/.ssh/authorized_keys
+   sudo -u git chmod 600 /home/git/.ssh/authorized_keys
+   ```
+
+4. Setup `ssh-shell`
+
+   ```sh
+   cat <<"EOF" | sudo tee /home/git/ssh-shell
+   #!/bin/sh
+   shift
+   ssh -p 2222 -o StrictHostKeyChecking=no git@127.0.0.1 "SSH_ORIGINAL_COMMAND=\"$SSH_ORIGINAL_COMMAND\" $@"
+   EOF
+   sudo chmod +x /home/git/ssh-shell
+   sudo usermod -s /home/git/ssh-shell git
+   ```
+
+5. Fix ownership
+
+   ```sh
+   sudo chown git:git -Rc /home/git
+   ```

--- a/phantom/forgejo/README.md
+++ b/phantom/forgejo/README.md
@@ -1,5 +1,19 @@
 # Forgejo
 
+## `app.ini`
+
+It's easier to view the `app.ini` file locally.
+
+```sh
+# Export
+sudo cp /var/lib/docker/volumes/phantom_forgejo/_data/gitea/conf/app.ini ./forgejo/secrets/app.ini
+sudo chown $USER:$USER -Rc ./forgejo/secrets/app.ini
+
+# Import
+sudo cp ./forgejo/secrets/app.ini /var/lib/docker/volumes/phantom_forgejo/_data/gitea/conf/app.ini
+sudo chown git:git -Rc /var/lib/docker/volumes/phantom_forgejo/_data/gitea/conf/app.ini
+```
+
 ## Setup SSH Passthrough
 
 1. Create a user

--- a/phantom/forgejo/compose.yaml
+++ b/phantom/forgejo/compose.yaml
@@ -1,6 +1,10 @@
 networks:
   forgejo-postgres:
 
+secrets:
+  app:
+    file: ./secrets/app.ini
+
 services:
   forgejo:
     container_name: forgejo
@@ -49,8 +53,14 @@ services:
       - authentik-forgejo
       - caddy-forgejo
       - forgejo-postgres
+    ports:
+      - 127.0.0.1:2222:22
     restart: always
+    secrets:
+      - source: app
+        target: /data/gitea/conf/app.ini
     volumes:
+      - /home/git/.ssh/:/data/git/.ssh
       - forgejo:/data
 
       - /etc/localtime:/etc/localtime:ro

--- a/phantom/forgejo/compose.yaml
+++ b/phantom/forgejo/compose.yaml
@@ -1,10 +1,6 @@
 networks:
   forgejo-postgres:
 
-secrets:
-  app:
-    file: ./secrets/app.ini
-
 services:
   forgejo:
     container_name: forgejo
@@ -56,9 +52,6 @@ services:
     ports:
       - 127.0.0.1:2222:22
     restart: always
-    secrets:
-      - source: app
-        target: /data/gitea/conf/app.ini
     volumes:
       - /home/git/.ssh/:/data/git/.ssh
       - forgejo:/data

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  smol-toml@<1.6.1: ^1.6.1
+
 importers:
 
   .:
@@ -367,8 +370,8 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
-  smol-toml@1.6.0:
-    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
   sql-formatter@15.7.3:
@@ -571,7 +574,7 @@ snapshots:
       markdownlint: 0.40.0
       markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.0)
       micromatch: 4.0.8
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -831,7 +834,7 @@ snapshots:
 
   slash@5.1.0: {}
 
-  smol-toml@1.6.0: {}
+  smol-toml@1.6.1: {}
 
   sql-formatter@15.7.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,8 +192,8 @@ packages:
     resolution: {integrity: sha512-HIf1uwublnXZsy7p3yHTrhzMzrLO6xKnqXytT9pEil5QxaXi8eyer7Is4luF5hYSV4kD3v03Y32FWoAeVYTghQ==}
     hasBin: true
 
-  katex@0.16.44:
-    resolution: {integrity: sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==}
+  katex@0.16.45:
+    resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
     hasBin: true
 
   linkify-it@5.0.0:
@@ -540,7 +540,7 @@ snapshots:
 
   jsox@1.2.125: {}
 
-  katex@0.16.44:
+  katex@0.16.45:
     dependencies:
       commander: 8.3.0
 
@@ -652,7 +652,7 @@ snapshots:
     dependencies:
       '@types/katex': 0.16.8
       devlop: 1.1.0
-      katex: 0.16.44
+      katex: 0.16.45
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+overrides:
+  smol-toml@<1.6.1: ^1.6.1


### PR DESCRIPTION
* Related to https://github.com/NatoBoram/docker-compose/issues/97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

Enable SSH passthrough for Forgejo via host SSH binding and related configuration.

### Added

- ✨ Add SSH passthrough docs in `phantom/forgejo/README.md`
- ✨ Expose `22` as `127.0.0.1:2222` in `phantom/forgejo/compose.yaml`
- ✨ Mount `/home/git/.ssh/` to `/data/git/.ssh` in `phantom/forgejo/compose.yaml`
- ✨ Add `USER_UID` and `USER_GID` in `phantom/forgejo/.env.forgejo`
- ✨ Add `FORGEJO__mailer__PROTOCOL` in `phantom/forgejo/.env.forgejo`
- 📌 Pin `smol-toml` to `^1.6.1` in `pnpm-workspace.yaml`

### Changed

- 🔧 Set `FORGEJO__mailer__SMTP_PORT` from `465` to empty in `phantom/forgejo/.env.forgejo`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->